### PR TITLE
Enable es6 in server-side code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ jspm_packages
 .node_repl_history
 
 server/static/bundle.*
+server/lib

--- a/package.json
+++ b/package.json
@@ -4,20 +4,21 @@
   "description": "An app for students to anonymously ask 'stupid' questions.",
   "main": "server/server.js",
   "scripts": {
-    "build": "webpack",
     "testerino": "webpack --watch",
-    
-    "postinstall": "webpack",
     "watch": "webpack-dev-server --hot --inline",
-    "start": "node server/server",
-    "server": "node-inspector --web-port 8888 & node-dev --debug server/server",
+    "build": "webpack && npm run transpile",
+    "lint": "eslint . --ext .js --ext .jsx --cache",
+    "postinstall": "npm run build",
+    "start": "node server/lib/server",
+    "server": "node-inspector --web-port 8888 & npm run transpile && node-dev --debug server/lib/server",
     "test": "ava --watch",
     "init": "knex init",
     "migrate:make": "knex migrate:make",
     "migrate:latest": "knex migrate:latest",
     "migrate:rollback": "knex migrate:rollback",
     "seed:make": "knex seed:make",
-    "seed:run": "knex seed:run"
+    "seed:run": "knex seed:run",
+    "transpile": "babel server --ignore server/lib,server/static --out-dir server/lib"
   },
   "ava": {
     "failfast": true,
@@ -52,6 +53,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
+    "babel-cli": "^6.10.1",
     "body-parser": "^1.15.1",
     "express": "^4.13.4",
     "react": "^15.1.0",

--- a/server/db.js
+++ b/server/db.js
@@ -1,5 +1,5 @@
 import knex from 'knex'
-import config from '../knexfile'
+import config from '../../knexfile'
 
 function getConnection () {
   return knex(config.development)


### PR DESCRIPTION
- Server now launches from server/lib/server.js
- Static content still served from server/static
- `transpile` server script added
- Development server still launched (with debug) from `npm run server`

This PR fixes the issues unearthed so far with the mixture of es6 and es5 in the server-side code.
